### PR TITLE
detect include loop

### DIFF
--- a/spf.go
+++ b/spf.go
@@ -211,6 +211,12 @@ func NewSPF(domain, record string) (*SPF, error) {
 				return spf, errors.New(fmt.Sprintf("Invalid mechanism in SPF string: %s", f))
 			}
 
+			if mechanism.Name == "include" {
+				if mechanism.Domain == domain {
+					return spf, fmt.Errorf("include loop detected")
+				}
+			}
+
 			spf.Mechanisms = append(spf.Mechanisms, mechanism)
 		}
 	}

--- a/spf_test.go
+++ b/spf_test.go
@@ -68,6 +68,7 @@ func TestNewSPF(t *testing.T) {
 	errorTests := []spferror{
 		spferror{"google.com", "somestring"},
 		spferror{"google.com", "v=spf1 include:_spf.google.com ~all -none"},
+		spferror{"google.com", "v=spf1 include:google.com"},
 	}
 
 	for _, expected := range errorTests {


### PR DESCRIPTION
I've encountered a dns entry that had an include loop, resulting in a stack overflow. This detects it and returns an error. It will only detect a one level loop.