### PR TITLE
Provide functions to translate SPF object to canonical string and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Mechanism represents a single mechanism in an SPF record.
 	Name   string
 	Domain string
 	Prefix string
+  Result string
     }
 
 func (*Mechanism) String()
@@ -24,18 +25,30 @@ func (*Mechanism) String()
 
 Return a Mechanism as a string
 
+func (*Mechanism) ResultTag()
+-----------------------------
+
+    func (m *Mechanism) ResultTag() string
+
+Returns the sigil that describes the result of this mechanism (i.e., "+" for "Pass", etc.)
+
+func (m *Mechanism) SPFString()
+-------------------------------
+
+    func (m *Mechanism) SPFString() string
+
+Returns a string representation of the mechanism in a format suitable for addition to a SPF record in the DNS.
+
 type SPF
 --------
 SPF represents an SPF record for a particular Domain. The SPF record
-holds all of the Allow, Deny, and Neutral mechanisms.
+holds all of the mechanisms describing the policy.
 
     type SPF struct {
-        Raw     string
-        Domain  string
-        Version string
-        Allow   []*Mechanism
-        Deny    []*Mechanism
-        Neutral []*Mechanism
+        Raw          string
+        Domain       string
+        Version      string
+        Mechanisms   []*Mechanism
     }
 
 func (*SPF) Allowed
@@ -51,6 +64,13 @@ func (*SPF) String
     func (s *SPF) String() string
 
 Return an SPF record as a string.
+
+func (s *SPF) SPFString()
+-------------------------
+
+    func (s *SPF) SPFString() string
+
+Returns a DNS record - compatible representation of the SPF policy described by the SPF object.
 
 func NetworkCIDR
 ----------------
@@ -83,6 +103,3 @@ func NewSPFString
 
 Create a new SPF record for the given domain using the provided string.
 If the provided string is not valid an error is returned.
-
-
-

--- a/spf.go
+++ b/spf.go
@@ -43,6 +43,48 @@ func (m *Mechanism) String() string {
 	return buf.String()
 }
 
+// ResultTag maps the Result code to a suitable char
+func (m *Mechanism) ResultTag() string {
+	switch m.Result {
+	case "Fail":
+		return "-"
+	case "SoftFail":
+		return "~"
+	case "Pass":
+		return "+"
+	case "Neutral":
+		return "?"
+	}
+
+	return "+"
+}
+
+// SPFString return a string representation of a mechanism, suitable for using
+// in a TXT record.
+func (m *Mechanism) SPFString() string {
+	var buf bytes.Buffer
+
+	tag := m.ResultTag()
+
+	if m.Name != "all" && tag != "+" {
+		buf.WriteString(tag)
+	} else if m.Name == "all" {
+		buf.WriteString(tag)
+	}
+
+	buf.WriteString(m.Name)
+
+	if len(m.Domain) != 0 && m.Name != "all" {
+		buf.WriteString(fmt.Sprintf(":%s", m.Domain))
+	}
+
+	if len(m.Prefix) != 0 {
+		buf.WriteString(fmt.Sprintf("/%s", m.Prefix))
+	}
+
+	return buf.String()
+}
+
 // Ensure the mechanism is valid
 func (m *Mechanism) Valid() bool {
 	var result bool
@@ -183,6 +225,19 @@ func (s *SPF) String() string {
 	buf.WriteString("Mechanisms:\n")
 	for _, m := range s.Mechanisms {
 		buf.WriteString(fmt.Sprintf("\t%s\n", m.String()))
+	}
+
+	return buf.String()
+}
+
+// SPFString returns a formatted SPF object as a string suitable for use in a
+// TXT record.
+func (s *SPF) SPFString() string {
+	var buf bytes.Buffer
+
+	buf.WriteString(fmt.Sprintf("v=%s", s.Version))
+	for _, m := range s.Mechanisms {
+		buf.WriteString(fmt.Sprintf(" %s", m.SPFString()))
 	}
 
 	return buf.String()

--- a/spf_test.go
+++ b/spf_test.go
@@ -25,6 +25,11 @@ type spftest struct {
 	result string
 }
 
+type spfstr struct {
+	raw      string
+	expected string
+}
+
 func TestNewMechanism(t *testing.T) {
 	tests := []mechtest{
 		mechtest{"+all", "all", domain, "", "Pass"},
@@ -93,6 +98,31 @@ func TestSPFTest(t *testing.T) {
 
 		if actual != expected.result {
 			t.Error("Expected", expected.result, "got", actual)
+		}
+	}
+}
+
+func TestSPFString(t *testing.T) {
+	tests := []spfstr{
+		spfstr{
+			"v=spf1 ip4:45.55.100.54 ip4:192.241.161.190 ip4:188.226.145.26 ~all",
+			"v=spf1 ip4:45.55.100.54 ip4:192.241.161.190 ip4:188.226.145.26 ~all",
+		},
+		spfstr{
+			"v=spf1 ip4:127.0.0.0/8 -ip4:127.0.0.1 ?ip4:127.0.0.2 -all",
+			"v=spf1 ip4:127.0.0.0/8 -ip4:127.0.0.1 ?ip4:127.0.0.2 -all",
+		},
+	}
+
+	for _, tcase := range tests {
+		s, err := NewSPF("domain", tcase.raw)
+		if err != nil {
+			t.Error(err)
+		}
+
+		r := s.SPFString()
+		if r != tcase.expected {
+			t.Error("Expected", tcase.expected, "got", r)
 		}
 	}
 }


### PR DESCRIPTION
Added code required to produce the TXT record contents from the SPF data already in an object.