### PR TITLE
Move types to their own file. Implement parsing of redirect= mechanism

### DIFF
--- a/spf.go
+++ b/spf.go
@@ -328,8 +328,6 @@ func parseMechanism(str, domain string, m *Mechanism) {
 	ei := strings.Index(str, "=")
 	pi := strings.Index(str, "/")
 
-	fmt.Printf("str=%s domain=%s (ci=%d ei=%d pi=%d)\n", str, domain, ci, ei, pi)
-
 	switch {
 	case ci != -1 && pi != -1: // name:domain/prefix
 		m.Name = str[:ci]

--- a/spf_test.go
+++ b/spf_test.go
@@ -55,16 +55,16 @@ func TestNewMechanism(t *testing.T) {
 		actual := NewMechanism(expected.raw, domain)
 
 		if expected.name != actual.Name {
-			t.Error("Expected", expected.name, "got", actual.Name, ":", expected.raw)
+			t.Error("Expected name", expected.name, "got", actual.Name, ":", expected.raw)
 		}
 		if expected.domain != actual.Domain {
-			t.Error("Expected", expected.domain, "got", actual.Domain, ":", expected.raw)
+			t.Error("Expected domain", expected.domain, "got", actual.Domain, ":", expected.raw)
 		}
 		if expected.prefix != actual.Prefix {
-			t.Error("Expected", expected.prefix, "got", actual.Prefix, ":", expected.raw)
+			t.Error("Expected prefix", expected.prefix, "got", actual.Prefix, ":", expected.raw)
 		}
 		if expected.result != actual.Result {
-			t.Error("Expected", expected.prefix, "got", actual.Prefix, ":", expected.raw)
+			t.Error("Expected result", expected.result, "got", actual.Result, ":", expected.raw)
 		}
 	}
 }
@@ -74,13 +74,21 @@ func TestNewSPF(t *testing.T) {
 		spferror{"google.com", "somestring"},
 		spferror{"google.com", "v=spf1 include:_spf.google.com ~all -none"},
 		spferror{"google.com", "v=spf1 include:google.com"},
+		spferror{"google.com", "v=spf1 ip4:"},
+		spferror{"google.com", "v=spf1 include:"},
+		spferror{"google.com", "v=spf1 ip4:127.0.0.1/"},
+		spferror{"google.com", "v=spf1 ip4:/"},
+		spferror{"google.com", "v=spf1 ip4/:"},
+		spferror{"google.com", "v=spf1 /:"},
+		spferror{"google.com", "v=spf1 :/"},
 	}
 
 	for _, expected := range errorTests {
 		_, err := NewSPF(expected.domain, expected.raw)
 
 		if err == nil {
-			t.Error("Expected error got nil")
+			t.Logf("analyzing \"%s\"", expected.raw)
+			t.Error("Expected error, got nil")
 		}
 	}
 }

--- a/spf_test.go
+++ b/spf_test.go
@@ -113,6 +113,10 @@ func TestSPFString(t *testing.T) {
 			"v=spf1 ip4:127.0.0.0/8 -ip4:127.0.0.1 ?ip4:127.0.0.2 -all",
 			"v=spf1 ip4:127.0.0.0/8 -ip4:127.0.0.1 ?ip4:127.0.0.2 -all",
 		},
+		spfstr{
+			"v=spf1 redirect=_spf.sample.invalid",
+			"v=spf1 redirect=_spf.sample.invalid",
+		},
 	}
 
 	for _, tcase := range tests {

--- a/types.go
+++ b/types.go
@@ -1,0 +1,18 @@
+package spf
+
+// Mechanism represents a single mechanism in an SPF record.
+type Mechanism struct {
+	Name   string
+	Domain string
+	Prefix string
+	Result string
+}
+
+// SPF represents an SPF record for a particular Domain. The SPF record
+// holds all of the Allow, Deny, and Neutral mechanisms.
+type SPF struct {
+	Raw        string
+	Domain     string
+	Version    string
+	Mechanisms []*Mechanism
+}

--- a/types.go
+++ b/types.go
@@ -1,5 +1,7 @@
 package spf
 
+import "errors"
+
 // Mechanism represents a single mechanism in an SPF record.
 type Mechanism struct {
 	Name   string
@@ -16,3 +18,7 @@ type SPF struct {
 	Version    string
 	Mechanisms []*Mechanism
 }
+
+// ErrPermFail is a special error triggered by malformed SPF records as per
+// RFC-7208 § 4.6
+var ErrPermFail = errors.New("ErrPermFail: Invalid SPF record")


### PR DESCRIPTION
The main change here is to allow SPF records with redirect= mechanisms to be parsed. Evaluation can be implemented later if warranted.
