### PR TITLE
Fix a bug in the 'redirect' mechanism. 

### DIFF
--- a/mechanism.go
+++ b/mechanism.go
@@ -150,6 +150,8 @@ func (m *Mechanism) Evaluate(ip string, count int) (Result, error) {
 		// There is no clear definition of what to do with errors on a
 		// redirected domain. Trying to make wise choices here.
 		switch err {
+		case nil:
+			break
 		case ErrFailedLookup:
 			return TempError, nil
 		default:


### PR DESCRIPTION
A non nil error would cause a PermError to be returned instead of executing the test.